### PR TITLE
Filled out javadocs for all powerup subtypes

### DIFF
--- a/.idea/checkstyleidea-libs/readme.txt
+++ b/.idea/checkstyleidea-libs/readme.txt
@@ -1,0 +1,6 @@
+This folder contains libraries copied from the "project-team-paul" project.
+It is managed by the CheckStyle-IDEA IDE plugin.
+Do not modify this folder while the IDE is running.
+When the IDE is stopped, you may delete this folder at any time. It will be recreated as needed.
+In order to prevent the CheckStyle-IDEA IDE plugin from creating this folder,
+uncheck the "Copy libraries from project directory" option in the CheckStyle-IDEA settings dialog.

--- a/src/main/java/org/bcit/comp2522/JaydenJump/ExtraLife.java
+++ b/src/main/java/org/bcit/comp2522/JaydenJump/ExtraLife.java
@@ -4,11 +4,39 @@ import processing.core.PImage;
 
 import java.awt.*;
 
+/**
+ * A type of PowerUp that gives the player an extra life in the game.
+ *
+ * @version 1.0
+ *
+ * @author Shawn Birring
+ *
+ * @since 2023-03-22
+ */
+
 public class ExtraLife extends PowerUp{
-  public ExtraLife(int xpos, int ypos, int vx, int vy, int width, int height, boolean isActive, Color color, PImage image) {
+
+  /**
+   * Creates an instance of ExtraLife powerup in the game.
+   *
+   * @param xpos The x position of ExtraLife
+   * @param ypos The y position of ExtraLife
+   * @param vx The x velocity of ExtraLife
+   * @param vy The y velocity of ExtraLife
+   * @param width The width of ExtraLife
+   * @param height The height of ExtraLife
+   * @param isActive The boolean state that determines whether ExtraLife is active or not
+   * @param color The color of ExtraLife
+   * @param image The image of ExtraLife
+   */
+  public ExtraLife(int xpos, int ypos, int vx, int vy, int width, int height,
+                   boolean isActive, Color color, PImage image) {
     super(xpos, ypos, vx, vy, width, height, isActive, color, image);
   }
 
+  /**
+   * Increases the life of the Player by one.
+   */
   public void increaseLife() {
 
   }

--- a/src/main/java/org/bcit/comp2522/JaydenJump/JetPack.java
+++ b/src/main/java/org/bcit/comp2522/JaydenJump/JetPack.java
@@ -3,12 +3,39 @@ package org.bcit.comp2522.JaydenJump;
 import processing.core.PImage;
 import java.awt.Color;
 
-public class JetPack extends PowerUp{
+/**
+ * The JetPack class is a type of PowerUp that allows the Player to fly up
+ * screen for a certain period of time.
+ *
+ * @version 1.0
+ *
+ * @author Shawn Birring
+ *
+ * @since 2023-03-23
+ */
 
+public class JetPack extends PowerUp{
+  /** The amount of time the JetPack lasts. */
   private int duration;
 
+  /** The amount the y velocity of the player is increased. */
   private int boostVelocity;
 
+  /**
+   * Creates an Instance of a JetPack in the game.
+   *
+   * @param xpos The x position of JetPack
+   * @param ypos The y position of JetPack
+   * @param vx The x velocity of JetPack
+   * @param vy The y velocity of JetPack
+   * @param width The width of JetPack
+   * @param height The height of JetPack
+   * @param isActive The boolean state that determines whether JetPack is active or not
+   * @param color The color of JetPack
+   * @param image The image of JetPack
+   * @param duration The amount of time the JetPack lasts for
+   * @param boostVelocity The amount the y direction of Player is affected by JetPack
+   */
   public JetPack(int xpos, int ypos, int vx, int vy, int width, int height, boolean isActive, Color color, PImage image, int duration, int boostVelocity) {
     super(xpos, ypos, vx, vy, width, height, isActive, color, image);
     this.duration = duration;

--- a/src/main/java/org/bcit/comp2522/JaydenJump/Magnet.java
+++ b/src/main/java/org/bcit/comp2522/JaydenJump/Magnet.java
@@ -3,19 +3,64 @@ package org.bcit.comp2522.JaydenJump;
 import java.awt.Color;
 import processing.core.PImage;
 
-public class Magnet extends PowerUp{
+/**
+ * The Magnet class is a type of PowerUp that collects coins around the Player
+ * with a certain radius, without the Player having to directly touch the coin.
+ *
+ * @version 1.0
+ *
+ * @author Shawn Birring
+ *
+ * @since 2023-03-22
+ */
 
+public class Magnet extends PowerUp{
+  /** The amount of time the Magnet is active for. */
   private int duration;
 
+  /** The radius of the magnet that can grab the coins. */
   private int radius;
 
+  /**
+   * Creates an instance of a Magnet in the game.
+   *
+   * @param xpos The x position of the Magnet
+   *
+   * @param ypos The y position of the Magnet
+   *
+   * @param vx The x velocity of the Magnet
+   *
+   * @param vy The y velocity of the Magnet
+   *
+   * @param width The width of the Magnet
+   *
+   * @param height The height of the Magnet
+   *
+   * @param isActive The boolean state that determines if the Magnet is active or not
+   *
+   * @param color The color of the Magnet
+   *
+   * @param image The image of the Magnet
+   *
+   * @param duration The amount of time the Magnet lasts for
+   *
+   * @param radius The radius that the Magnet affects
+   */
   public Magnet(int xpos, int ypos, int vx, int vy, int width, int height, boolean isActive, Color color, PImage image,  int duration, int radius) {
     super(xpos, ypos, vx, vy, width, height, isActive, color, image);
     this.duration = duration;
     this.radius = radius;
   }
 
+  /** Checks to see if a coin is within radius of the Player.  */
   public void checkDistance() {}
+
+  /**
+   * Adds a coin to the Player if it is within radius of Player
+   * with the magnet powerup
+   *
+   * @param coin in the game
+   */
   public void collectCoin(Coin coin) {}
 
 }

--- a/src/main/java/org/bcit/comp2522/JaydenJump/SpringShoes.java
+++ b/src/main/java/org/bcit/comp2522/JaydenJump/SpringShoes.java
@@ -1,15 +1,54 @@
 package org.bcit.comp2522.JaydenJump;
 
 import java.awt.Color;
-
 import processing.core.PImage;
+
+/**
+ * The SpringShoes class is a type of PowerUp that increases the y velocity the player
+ * for a certain length of time (allows Player to jump greater heights).
+ *
+ * @version 1.0
+ *
+ * @author Shawn Birring
+ *
+ * @since 2023-03-22
+ */
 
 public class SpringShoes extends PowerUp {
 
+  /** The amount that affects the y velocity of the Player. */
   private int boostValue;
+
+  /** The length of time the Player's x velocity is affected for. */
   private int duration;
 
-  public SpringShoes(int xpos, int ypos, int vx, int vy, int width, int height, boolean isActive, Color color, PImage image, int duration, int boostValue) {
+  /**
+   * Creates an instance of the SpringShoes class in the game.
+   *
+   * @param xpos The x position of SpringShoes
+   *
+   * @param ypos The y position of SpringShoes
+   *
+   * @param vx The x velocity of SpringShoes
+   *
+   * @param vy The y velocity of SpringShoes
+   *
+   * @param width The width of SpringShoes
+   *
+   * @param height The height of SpringShoes
+   *
+   * @param isActive The boolean state of SpringShoes that determines if it is active or not
+   *
+   * @param color The color of SpringShoes
+   *
+   * @param image The image of SpringShoes
+   *
+   * @param duration How long the SpringShoes last for
+   *
+   * @param boostValue The amount that affects the y velocity of SpringShoes
+   */
+  public SpringShoes(int xpos, int ypos, int vx, int vy, int width, int height,
+                     boolean isActive, Color color, PImage image, int duration, int boostValue) {
     super(xpos, ypos, vx, vy, width, height, isActive, color, image);
     this.boostValue = boostValue;
     this.duration = duration;

--- a/src/main/java/org/bcit/comp2522/JaydenJump/Tire.java
+++ b/src/main/java/org/bcit/comp2522/JaydenJump/Tire.java
@@ -1,22 +1,70 @@
 package org.bcit.comp2522.JaydenJump;
+
 import java.awt.Color;
 import processing.core.PImage;
 
+/**
+ * The Tire class is a type of PowerUp that the Player can interact
+ * with to be able momentarily to jump higher.
+ *
+ * @version 1.0
+ *
+ * @author Shawn Birring
+ *
+ * @since 2023-03-22
+ */
 
-public class Tire extends PowerUp{
+public class Tire extends PowerUp {
 
-  public Tire(int xpos, int ypos, int vx, int vy, int width, int height, boolean isActive, Color color, PImage image) {
+  /**
+   * Creates an instance of the Tire class in the game.
+   *
+   * @param xpos The x position of the Tire
+   *
+   * @param ypos The y position of the Tire
+   *
+   * @param vx The x velocity of the Tire
+   *
+   * @param vy The y Velocity of the Tire
+   *
+   * @param width The width of the Tire
+   *
+   * @param height The height of the Tire
+   *
+   * @param isActive The boolean state that determines if the Tire is active or not
+   *
+   * @param color The color of the Tire
+   *
+   * @param image The image of the Tire
+   */
+  public Tire(int xpos, int ypos, int vx, int vy, int width, int height,
+              boolean isActive, Color color, PImage image) {
     super(xpos, ypos, vx, vy, width, height, isActive, color, image);
   }
+
+  /** The amount that affects the jump height of the Player. */
   private int boostHeight;
 
+  /**
+   * Retrieves the boost height of Tire.
+   *
+   * @return boostHeight of Tire
+   */
   public int getBoostHeight() {
     return boostHeight;
   }
 
+  /**
+   * Reassigns boost height of Tire to a different value.
+   *
+   * @param boostHeight of Tire that changes the current boostHeight
+   */
   public void setBoostHeight(int boostHeight) {
     this.boostHeight = boostHeight;
   }
 
+  /**
+   * Boosts the height of the player.
+   */
   public void boostPlayer() {}
 }


### PR DESCRIPTION
I filled out javadocs for all subclasses of powerup (tire, extralife, jetpack, springshoes, magnet). However some of the documentation still needs to be worked on as I was not clear on what exactly each method does yet.